### PR TITLE
Read from folder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +284,7 @@ dependencies = [
 name = "solar-rs"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "csv",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.71"
 chrono = { version = "0.4.24", features = ["serde"] }
 csv = "1.2.1"
 itertools = "0.10.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 use solar_rs::solar_data::SolarData;
-use std::fs::read_dir;
 
-fn main() {
-    let dir = read_dir("data").unwrap();
-    let data = SolarData::from(dir);
+fn main() -> anyhow::Result<()> {
+    let data = SolarData::from_folder("data")?;
 
-    println!("{}", data)
+    println!("{}", data);
+
+    Ok(())
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -18,7 +18,11 @@ where
     Ok(records)
 }
 
-pub fn write_to_file<T: Serialize>(path: &str, records: &[T]) -> Result<(), Box<dyn Error>> {
+pub fn write_to_file<T, P>(path: &str, records: &[T]) -> Result<(), Box<dyn Error>>
+where
+    T: Serialize,
+    P: AsRef<Path>,
+{
     let mut wtr = csv::Writer::from_path(path)?;
 
     for record in records {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,8 +1,12 @@
-use std::error::Error;
+use std::{error::Error, path::Path};
 
 use serde::{Deserialize, Serialize};
 
-pub fn read_from_file<T: for<'de> Deserialize<'de>>(path: &str) -> Result<Vec<T>, Box<dyn Error>> {
+pub fn read_from_file<T, P>(path: P) -> Result<Vec<T>, csv::Error>
+where
+    T: for<'de> Deserialize<'de>,
+    P: AsRef<Path>,
+{
     let mut rdr = csv::Reader::from_path(path)?;
     let mut records = Vec::new();
 


### PR DESCRIPTION
This method is more semantic than a From<ReadDir> implementation which can fail. According to Rust docs `From` should never fail:

> Note: This trait must not fail. The From trait is intended for perfect conversions. If the conversion can fail or is not perfect, use [TryFrom](https://doc.rust-lang.org/std/convert/trait.TryFrom.html).

`TryFrom<ReadDir>` still feels unsemantic as this isn't a simple type conversion but more complicated process involving file io.

Added proper error checking & removed `unwrap()`'s. Most errors will bubble up if a `Result` is returned but it some cases we ignore these errors. (e.g. `DirEntry::file_type` returns a `Result`, it's unclear why so imo it's better to skip the entry if this happens and still read the rest of the files)

Added `anyhow` for easier usage of `Result` to avoid having to manually convert between different `Error` implementations. This can be improved in the future when a custom `Error` type is added.

Changed parse::read_from_file to accept `AsRef<Path>` instead of `&str` to be more generic.

Updated main to mirror recent changed to accept folder path from the command file.